### PR TITLE
Fix user controls dropdown styles on Flaum 1.0

### DIFF
--- a/resources/less/components/list.less
+++ b/resources/less/components/list.less
@@ -34,9 +34,12 @@
                 color: #fff !important;
             }
         }
-        .Dropdown-menu {
-            // for not overlapping header
-            z-index: @zindex-header - 1;
+
+        @media @tablet-up {
+            .Dropdown-menu {
+                // for not overlapping header
+                z-index: @zindex-header - 1;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR fixes issues with dropdown styles after upgrading to Flarum 1.0

TODO

- [ ] Fix Small User Cards 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
I'm not sure what to do with small cards. I've spent two hours trying to troubleshoot the z-index problems there and each time something has to be sacrificed to make it work.
Maybe just remove user controls when small cards are enabled?
Another option would be to copy the entire `viev()` from `UserCard` to `SmallUserCard` just to change the order in the HTML. If `div.UserCard-controls` is after `div.UserCard-profile`, then the problem will be solved. But is there any point in copying the whole component just to change this one thing?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/25438601/120427455-394d7e00-c372-11eb-9ebd-26136c128343.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/25438601/120427370-14590b00-c372-11eb-851e-efba5e448cbb.png)

</details>

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
