### PR TITLE
Add option to disable User Directory global search source

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,4 +1,4 @@
-import app from 'flarum/common/app';
+import app from 'flarum/admin/app';
 import SortMap from '../common/utils/SortMap';
 
 export { SortMap };
@@ -22,6 +22,11 @@ app.initializers.add('fof-user-directory', (app) => {
         .registerSetting({
             setting: 'fof-user-directory.use-small-cards',
             label: app.translator.trans('fof-user-directory.admin.settings.use-small-cards'),
+            type: 'boolean',
+        })
+        .registerSetting({
+            setting: 'fof-user-directory.disable-global-search-source',
+            label: app.translator.trans('fof-user-directory.admin.settings.disable-global-search-source'),
             type: 'boolean',
         })
         .registerSetting({

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -1,5 +1,5 @@
 import { extend } from 'flarum/common/extend';
-import app from 'flarum/common/app';
+import app from 'flarum/forum/app';
 import UsersSearchSource from 'flarum/common/components/UsersSearchSource';
 import LinkButton from 'flarum/common/components/LinkButton';
 import IndexPage from 'flarum/common/components/IndexPage';
@@ -20,7 +20,7 @@ app.initializers.add('fof-user-directory', (app) => {
     };
 
     extend(UsersSearchSource.prototype, 'view', function (view, query) {
-        if (!view) {
+        if (!view || app.forum.attribute('userDirectoryDisableGlobalSearchSource')) {
             return;
         }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -21,6 +21,7 @@ fof-user-directory:
             link: Add link on homepage for users able to see the directory
             default-sort: Default sort
             use-small-cards: Use small user cards
+            disable-global-search-source: Do not add User Directory to the Flarum global search field
 
     lib:
         sort:

--- a/src/PermissionBasedForumSettings.php
+++ b/src/PermissionBasedForumSettings.php
@@ -33,6 +33,7 @@ class PermissionBasedForumSettings
         // The link is visible if the user can access the user directory AND the link was enabled in extension settings
         $attributes['canSeeUserDirectoryLink'] = $serializer->getActor()->can('fof.user-directory.view') && $this->settings->get('fof-user-directory-link');
         $attributes['userDirectorySmallCards'] = (bool) $this->settings->get('fof-user-directory.use-small-cards');
+        $attributes['userDirectoryDisableGlobalSearchSource'] = (bool) $this->settings->get('fof-user-directory.disable-global-search-source');
         $attributes['userDirectoryDefaultSort'] = $this->settings->get('fof-user-directory.default-sort') ?: 'default';
 
         // Only serialize if the actor has permission


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR adds an option to disable the User Directory search item that is added to the Flarum global search box. 

For some a temporary solution for #76 

**Screenshot**
![image](https://user-images.githubusercontent.com/25438601/124887770-c3be7880-dfd5-11eb-9a9a-03cbcde2b5d3.png)
![image](https://user-images.githubusercontent.com/25438601/124887859-dc2e9300-dfd5-11eb-815f-8a6d5fd5b99a.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes.