### PR TITLE
feat: Discussion and comment counts on the user directory listing

### DIFF
--- a/js/src/forum/components/UserDirectoryListItem.js
+++ b/js/src/forum/components/UserDirectoryListItem.js
@@ -1,6 +1,7 @@
 import Component from 'flarum/common/Component';
 import UserCard from 'flarum/forum/components/UserCard';
 import SmallUserCard from './SmallUserCard';
+import UserDirectoryUserCard from './UserDirectoryUserCard';
 
 export default class UserDirectoryListItem extends Component {
   view(vnode) {
@@ -12,6 +13,6 @@ export default class UserDirectoryListItem extends Component {
       controlsButtonClassName: 'Button Button--icon Button--flat',
     };
 
-    return <div className="User">{useSmallCards ? SmallUserCard.component(attributes) : UserCard.component(attributes)}</div>;
+    return <div className="User">{useSmallCards ? SmallUserCard.component(attributes) : UserDirectoryUserCard.component(attributes)}</div>;
   }
 }

--- a/js/src/forum/components/UserDirectoryPage.js
+++ b/js/src/forum/components/UserDirectoryPage.js
@@ -79,7 +79,7 @@ export default class UserDirectoryPage extends Page {
   sidebarItems() {
     const items = IndexPage.prototype.sidebarItems();
 
-    items.replace(
+    items.setContent(
       'nav',
       SelectDropdown.component(
         {
@@ -133,7 +133,8 @@ export default class UserDirectoryPage extends Page {
         options: sortOptions,
         value: this.state.getParams().sort || app.forum.attribute('userDirectoryDefaultSort'),
         onchange: this.changeParams.bind(this),
-      })
+      }),
+      100
     );
 
     items.add(
@@ -146,14 +147,16 @@ export default class UserDirectoryPage extends Page {
           className: 'GroupFilterDropdown',
         },
         this.groupItems().toArray()
-      )
+      ),
+      80
     );
 
     items.add(
       'search',
       SearchField.component({
         state: this.state,
-      })
+      }),
+      60
     );
 
     return items;

--- a/js/src/forum/components/UserDirectoryUserCard.js
+++ b/js/src/forum/components/UserDirectoryUserCard.js
@@ -1,0 +1,47 @@
+import UserCard from 'flarum/forum/components/UserCard';
+import ItemList from 'flarum/common/utils/ItemList';
+import humanTime from 'flarum/common/utils/humanTime';
+import icon from 'flarum/common/helpers/icon';
+import app from 'flarum/forum/app';
+
+export default class UserDirectoryUserCard extends UserCard {
+  /**
+   * Allowing to add additonal items unique to the user directory.
+   *
+   * @return {ItemList<import('mithril').Children>}
+   */
+  infoItems() {
+    const items = super.infoItems();
+    const user = this.attrs.user;
+
+    if (items.has('lastSeen')) items.setPriority('lastSeen', 100);
+    if (items.has('joined')) items.setPriority('joined', 95);
+    if (items.has('points')) items.setPriority('points', 60);
+    if (items.has('best-answer-count')) items.setPriority('best-answer-count', 68);
+    if (items.has('masquerade-bio')) items.setPriority('masquerade-bio', 50);
+
+    items.add(
+      'discussion-count',
+      <div className="userStat">
+        {icon('fas fa-comment')}
+        {app.translator.trans('fof-user-directory.forum.page.usercard.discussion-count', {
+          count: user.discussionCount(),
+        })}
+      </div>,
+      70
+    );
+
+    items.add(
+      'comment-count',
+      <div className="userStat">
+        {icon('fas fa-comments')}
+        {app.translator.trans('fof-user-directory.forum.page.usercard.post-count', {
+          count: user.commentCount(),
+        })}
+      </div>,
+      69
+    );
+
+    return items;
+  }
+}

--- a/js/src/forum/components/index.js
+++ b/js/src/forum/components/index.js
@@ -4,6 +4,7 @@ import SmallUserCard from './SmallUserCard';
 import UserDirectoryList from './UserDirectoryList';
 import UserDirectoryListItem from './UserDirectoryListItem';
 import UserDirectoryPage from './UserDirectoryPage';
+import UserDirectoryUserCard from './UserDirectoryUserCard';
 
 export const components = {
   CheckableButton,
@@ -12,4 +13,5 @@ export const components = {
   UserDirectoryList,
   UserDirectoryListItem,
   UserDirectoryPage,
+  UserDirectoryUserCard,
 };

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,3 +1,18 @@
 @import "components/toolbar";
 @import "components/list";
 @import "components/SearchFiled";
+
+.UserCard-info {
+    .item-discussion-stats {
+        display: block;
+        margin-top: 20px;
+    }
+}
+
+.UserCard {
+    .userStat {
+        .icon {
+            margin-right: 5px;
+          }
+    }
+  }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -16,6 +16,9 @@ fof-user-directory:
             load_more_button: => core.ref.load_more
             empty_text: We could not find any user matching your search.
             filter_button: Filter Groups
+            usercard:
+                discussion-count: "{count, plural, one { {count} discussion} other {{count} discussions}}"
+                post-count: "{count, plural, one { {count} post} other {{count} posts}}"
 
     admin:
         permissions:


### PR DESCRIPTION
Adds discussion and post counts to the specific `UserCard` for this extension. Existing user card is not changed.

solves #40 

![image](https://user-images.githubusercontent.com/16573496/169583660-812e7b88-365c-4cfc-a7d3-8ac9b4473c3a.png)

Image includes other extensions active (fof/best-answer, fof/user-bio, fof/gamification) adding their data as well