### PR TITLE
Fix for horizontal alignment of list items in the toolbar

### DIFF
--- a/resources/less/components/toolbar.less
+++ b/resources/less/components/toolbar.less
@@ -1,4 +1,7 @@
 .User--directory .IndexPage-toolbar {
+    .IndexPage-toolbar-view > li {
+        vertical-align: middle;
+    }
     @media @phone {
         display: flex;
         flex-direction: column;
@@ -71,8 +74,6 @@
 }
 
 .item-search {
-    vertical-align: bottom;
-
     @media @phone {
         margin-top: 5px;
         width: 100%;


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0001**

**Changes proposed in this pull request:**
Fix the horizontal alignment of the li items of the toolbar on Safari.

**Screenshot**
Before  (Safari 15.5)
![Screenshot 2022-08-31 at 17 10 11](https://user-images.githubusercontent.com/53989450/187713648-ea2d6b3f-508b-411e-a389-0dc87a634797.png)  

After  (Safari 15.5)
![Screenshot 2022-08-31 at 17 08 47](https://user-images.githubusercontent.com/53989450/187713364-4b5405c6-ed11-490d-aeb2-9df1a951d71a.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
