### PR TITLE
Fix multi-group search for more than 10 groups

### DIFF
--- a/js/src/forum/searchTypes/GroupFilter.js
+++ b/js/src/forum/searchTypes/GroupFilter.js
@@ -64,10 +64,15 @@ export default class GroupFilter extends AbstractType {
 
     const groups = [];
 
+    const queryGroups = qWithSpacesAround.split(' ').filter((q) => q.startsWith('group:'));
+
     app.store.all('groups').forEach((group) => {
-      if (qWithSpacesAround.indexOf('group:' + group.id()) !== -1) {
-        groups.push(group);
-      }
+      queryGroups.forEach((queryGroup) => {
+        const groupIds = queryGroup.replace('group:', '').split(',');
+        if (groupIds.includes(group.id())) {
+          groups.push(group);
+        }
+      });
     });
 
     return Promise.resolve(groups);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

## Description
This PR fixes a major issue in the search field related to the Group Filter. Previously, selecting multiple groups in the search field would produce incorrect behavior when there are more than 10 groups. This PR rectifies that.

**Reviewers should focus on:**
- The behavior of the search field when using the Group Filter. Please verify that the issue has been fixed, and no unintended side effects have been introduced.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
