### PR TITLE
[2.x] chore: bump PHPStan to level 6 and update PHPUnit configs for 12.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ js/node_modules/
 vendor/
 composer.lock
 .phpunit.result.cache
+.phpunit.cache
+tests/integration/tmp/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,7 @@ includes:
   - vendor/flarum/phpstan/extension.neon
 
 parameters:
-  # The level will be increased in Flarum 2.0
-  level: 5
+  level: 6
   paths:
     - extend.php
     - src

--- a/src/Access/UserPolicy.php
+++ b/src/Access/UserPolicy.php
@@ -16,7 +16,7 @@ use Flarum\User\User;
 
 class UserPolicy extends AbstractPolicy
 {
-    public function seeUserList(User $actor)
+    public function seeUserList(User $actor): bool
     {
         return $actor->hasPermission('fof.user-directory.view') && $actor->hasPermission('searchUsers');
     }

--- a/src/Content/UserDirectory.php
+++ b/src/Content/UserDirectory.php
@@ -44,7 +44,7 @@ class UserDirectory
     ) {
     }
 
-    private function getDocument(User $actor, array $params, Request $request)
+    private function getDocument(User $actor, array $params, Request $request): object
     {
         $actor->assertCan('seeUserList');
 
@@ -60,7 +60,10 @@ class UserDirectory
             $params['include'] .= ',groups';
         }
 
-        return json_decode($this->api->withQueryParams($params)->withParentRequest($request)->get('/users')->getBody());
+        return json_decode(
+            json: $this->api->withQueryParams($params)->withParentRequest($request)->get('/users')->getBody(),
+            associative: false
+        );
     }
 
     /**

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
+            <exclude>./integration/tmp</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
General 2.x maintenance to bring the repo in line with Flarum 2.0 standards.

## PHPStan level 6

Raised from level 5 (and dropped the stale `# The level will be increased in Flarum 2.0` comment). Level 6 surfaced two missing return types, both fixed at the source rather than suppressed:

- `UserPolicy::seeUserList(): bool` — the method only ever returns a boolean expression, and `AbstractPolicy::sanitizeResult()` accepts `string|bool|null`, so `bool` is accurate.
- `UserDirectory::getDocument(): object` — now decodes with an explicit `associative: false`, matching how Flarum core types the equivalent `Forum\Content\Index::getApiDocument()`. The blade template already relies on object access (`$apiDocument->data`).

No baseline entries, `@phpstan-ignore` comments, or widened types were added.

## PHPUnit 12 configs

Both `tests/phpunit.unit.xml` and `tests/phpunit.integration.xml` were still pointing at the hard-coded `https://schema.phpunit.de/9.3/phpunit.xsd` and using options removed in PHPUnit 10+. Updated to match the vendored 12.x schema (same shape as `fof/seo`):

- `xsi:noNamespaceSchemaLocation` → `../vendor/phpunit/phpunit/phpunit.xsd`
- `backupStaticAttributes` → `backupStaticProperties`
- Removed `convertErrorsToExceptions` / `convertNoticesToExceptions` / `convertWarningsToExceptions` (9.x-only)
- `<coverage processUncoveredFiles>` → `<source>`
- Removed the Mockery `<listeners>` block (listeners were removed in PHPUnit 10)
- Added `cacheDirectory=".phpunit.cache"`

`.phpunit.cache` and `tests/integration/tmp/` are now gitignored, since the new cache directory would otherwise be untracked noise.

## Verification

- `composer analyse:phpstan` → **OK, no errors** at level 6
- `composer test:integration` → **OK (13 tests, 45 assertions)** on PHPUnit 12.5.33, no schema or deprecation warnings
- `composer test:unit` → config parses cleanly (no unit tests exist in the repo yet)