### PR TITLE
[2.x] feat: add permission-gated "recently online" sort options

### DIFF
--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -29,6 +29,9 @@ export default [
         '': app.translator.trans('fof-user-directory.lib.sort.not_specified'),
       };
 
+      // Permissioned sorts are deliberately excluded. A forum-wide default that
+      // most users lack the permission to perform is exactly what broke the
+      // directory in issue #66.
       Object.keys(new SortMap().sortMap()).forEach((sort) => {
         sortOptions[sort] = app.translator.trans('fof-user-directory.lib.sort.' + sort);
       });

--- a/js/src/common/utils/SortMap.ts
+++ b/js/src/common/utils/SortMap.ts
@@ -1,4 +1,17 @@
 /**
+ * A sort option that is only available to actors holding a given permission.
+ */
+export interface PermissionedSort {
+  /** The API sort parameter. */
+  sort: string;
+  /**
+   * The forum attribute that reports whether the actor may use this sort.
+   * When it is not true, the option is hidden and never sent to the API.
+   */
+  attribute: string;
+}
+
+/**
  * The sort options for the user directory.
  *
  * Extensions can add custom sort options using the `extend` helper:
@@ -10,6 +23,14 @@
  * extend(SortMap.prototype, 'sortMap', function(map) {
  *   map.most_best_answers = '-bestAnswerCount';
  *   map.least_best_answers = 'bestAnswerCount';
+ * });
+ *
+ * Sorts that require a permission belong in `permissionedSortMap` instead, so
+ * they can be hidden from actors who would only get an API error:
+ *
+ * @example
+ * extend(SortMap.prototype, 'permissionedSortMap', function(map) {
+ *   map.my_sort = { sort: '-myField', attribute: 'canUseMySort' };
  * });
  */
 export default class SortMap {
@@ -25,6 +46,24 @@ export default class SortMap {
       oldest: 'joinedAt',
       most_discussions: '-discussionCount',
       least_discussions: 'discussionCount',
+    };
+
+    return map;
+  }
+
+  /**
+   * Get the sort options that are gated behind a permission.
+   *
+   * Core only exposes its `lastSeenAt` sort to holders of `user.viewLastSeenAt`
+   * and rejects the request outright for anyone else, so these must never be
+   * offered unconditionally — that was the cause of issue #66.
+   *
+   * @returns A map of sort keys to their API sort param and gating attribute
+   */
+  permissionedSortMap(): Record<string, PermissionedSort> {
+    const map: Record<string, PermissionedSort> = {
+      seen_recent: { sort: '-lastSeenAt', attribute: 'userDirectoryCanSortByLastSeen' },
+      seen_oldest: { sort: 'lastSeenAt', attribute: 'userDirectoryCanSortByLastSeen' },
     };
 
     return map;

--- a/js/src/forum/states/UserDirectoryListState.ts
+++ b/js/src/forum/states/UserDirectoryListState.ts
@@ -38,6 +38,9 @@ export default class UserDirectoryListState extends PaginatedListState<User, Use
     };
 
     const sortKey = this.params.sort || app.forum.attribute<string>('userDirectoryDefaultSort');
+    // An unknown key — including a permissioned sort this actor cannot use —
+    // leaves `sort` unset so the API applies its own default ordering, rather
+    // than erroring the whole list out.
     const sortValue = this.sortMap()[sortKey];
     params.sort = typeof sortValue === 'string' ? sortValue : sortValue?.sort;
 
@@ -67,6 +70,10 @@ export default class UserDirectoryListState extends PaginatedListState<User, Use
   /**
    * Get the sort map for the user directory.
    *
+   * Permissioned sorts are only included when the forum reports that the actor
+   * may use them, so a sort the API would reject can never be selected, sent,
+   * or restored from a URL — see issue #66.
+   *
    * **Note for extension developers**: Do NOT extend this method.
    * Instead, extend the `SortMap` class from `common/utils/SortMap`:
    *
@@ -79,9 +86,19 @@ export default class UserDirectoryListState extends PaginatedListState<User, Use
    * });
    */
   sortMap(): SortMapType {
+    const sortMap = new SortMap();
+    const permissioned: Record<string, string> = {};
+
+    for (const [key, { sort, attribute }] of Object.entries(sortMap.permissionedSortMap())) {
+      if (app.forum.attribute<boolean>(attribute)) {
+        permissioned[key] = sort;
+      }
+    }
+
     return {
       default: '',
-      ...new SortMap().sortMap(),
+      ...sortMap.sortMap(),
+      ...permissioned,
     };
   }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -41,7 +41,7 @@ fof-user-directory:
             username_za: Username (z-a)
             newest: Newest
             oldest: Oldest
-            most_posts: Most posts
-            least_posts: Least posts
             most_discussions: Most discussions
             least_discussions: Least discussions
+            seen_recent: Recently online
+            seen_oldest: Longest away

--- a/src/Api/PermissionBasedForumSettings.php
+++ b/src/Api/PermissionBasedForumSettings.php
@@ -30,6 +30,11 @@ class PermissionBasedForumSettings
                 ->get(fn ($forum, Context $context) => $context->getActor()->can('seeUserList') && $this->settings->get('fof-user-directory-link')),
             Schema\Str::make('userDirectoryDefaultSort')
                 ->get(fn () => $this->settings->get('fof-user-directory.default-sort') ?: 'default'),
+            Schema\Boolean::make('userDirectoryCanSortByLastSeen')
+                // Mirrors the gate core puts on its own `lastSeenAt` sort. The frontend
+                // hides the option entirely when this is false: offering a sort the API
+                // will reject with a 400 is what caused issue #66.
+                ->get(fn ($forum, Context $context) => $context->getActor()->hasPermission('user.viewLastSeenAt')),
             Schema\Boolean::make('hasSuspendPermission')
                 // Only serialize if the actor has permission
                 ->visible(fn ($forum, Context $context) => $context->getActor()->hasPermission('user.suspend'))

--- a/src/Content/UserDirectory.php
+++ b/src/Content/UserDirectory.php
@@ -37,11 +37,44 @@ class UserDirectory
         'least_discussions' => 'discussionCount',
     ];
 
+    /**
+     * Sorts that core only exposes to holders of `user.viewLastSeenAt`.
+     *
+     * Requesting one of these without the permission makes the API reject the
+     * whole request, so they are resolved separately and dropped for actors who
+     * cannot use them — see issue #66.
+     *
+     * @var array
+     */
+    private $permissionedSortMap = [
+        'seen_recent' => ['sort' => '-lastSeenAt', 'permission' => 'user.viewLastSeenAt'],
+        'seen_oldest' => ['sort' => 'lastSeenAt', 'permission' => 'user.viewLastSeenAt'],
+    ];
+
     public function __construct(
         protected Client $api,
         protected Factory $view,
         protected SettingsRepositoryInterface $settings
     ) {
+    }
+
+    /**
+     * Map a sort query param to its API sort param for the given actor.
+     *
+     * Unknown keys and permissioned sorts the actor cannot use both resolve to
+     * an empty string, so the directory falls back to the default ordering
+     * rather than sending a sort the API would reject.
+     */
+    private function resolveSort(?string $sort, User $actor): string
+    {
+        $sort ??= '';
+
+        if ($permissioned = Arr::get($this->permissionedSortMap, $sort)) {
+            return $actor->hasPermission($permissioned['permission']) ? $permissioned['sort'] : '';
+        }
+
+        // ?? used to prevent null values. null would result in the whole sortMap array being sent in the params
+        return Arr::get($this->sortMap, $sort, '');
     }
 
     private function getDocument(User $actor, array $params, Request $request): object
@@ -85,8 +118,7 @@ class UserDirectory
         }
 
         $params = [
-            // ?? used to prevent null values. null would result in the whole sortMap array being sent in the params
-            'sort'   => Arr::get($this->sortMap, $sort ?? '', ''),
+            'sort'   => $this->resolveSort($sort, $actor),
             'filter' => compact('q'),
             'page'   => ['offset' => ($page - 1) * 20, 'limit' => 20],
         ];

--- a/tests/integration/api/LastSeenPermissionAttributeTest.php
+++ b/tests/integration/api/LastSeenPermissionAttributeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of fof/user-directory.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\UserDirectory\tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The frontend needs to know whether the actor may use the last-seen sort so it
+ * can hide the option entirely. Exposing the option to someone who cannot use
+ * it is what produced the "Oops, something went wrong" of issue #66, so this
+ * attribute must track `user.viewLastSeenAt` exactly.
+ */
+class LastSeenPermissionAttributeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-user-directory');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    protected function forumAttributes(?int $actor): array
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
+        $response = $this->send($this->request('GET', '/api', $options));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+    }
+
+    #[Test]
+    public function admin_can_sort_by_last_seen()
+    {
+        $attributes = $this->forumAttributes(1);
+
+        $this->assertArrayHasKey('userDirectoryCanSortByLastSeen', $attributes);
+        $this->assertTrue($attributes['userDirectoryCanSortByLastSeen']);
+    }
+
+    #[Test]
+    public function normal_user_cannot_sort_by_last_seen_by_default()
+    {
+        $attributes = $this->forumAttributes(2);
+
+        $this->assertArrayHasKey('userDirectoryCanSortByLastSeen', $attributes);
+        $this->assertFalse($attributes['userDirectoryCanSortByLastSeen']);
+    }
+
+    #[Test]
+    public function guest_cannot_sort_by_last_seen()
+    {
+        $attributes = $this->forumAttributes(null);
+
+        $this->assertArrayHasKey('userDirectoryCanSortByLastSeen', $attributes);
+        $this->assertFalse($attributes['userDirectoryCanSortByLastSeen']);
+    }
+
+    #[Test]
+    public function normal_user_can_sort_by_last_seen_when_permission_granted()
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.viewLastSeenAt', 'group_id' => 3],
+            ],
+        ]);
+
+        $attributes = $this->forumAttributes(2);
+
+        $this->assertTrue($attributes['userDirectoryCanSortByLastSeen']);
+    }
+
+    #[Test]
+    public function guest_can_sort_by_last_seen_when_permission_granted()
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.viewLastSeenAt', 'group_id' => 2],
+            ],
+        ]);
+
+        $attributes = $this->forumAttributes(null);
+
+        $this->assertTrue($attributes['userDirectoryCanSortByLastSeen']);
+    }
+}

--- a/tests/integration/api/LastSeenSortTest.php
+++ b/tests/integration/api/LastSeenSortTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of fof/user-directory.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\UserDirectory\tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the "recently online" sort against the privacy regression of issue #66.
+ *
+ * In Flarum beta 15 the `lastSeenAt` sort was available to everyone, which let
+ * any user infer the online time of users who had opted out of disclosing it.
+ * Beta 16 restricted the sort to holders of `user.viewLastSeenAt`, and this
+ * extension removed its UI option in 9b37481 rather than gating it.
+ *
+ * These tests pin the contract we now rely on to re-expose the option safely:
+ * the sort must work for permitted actors, and must be rejected outright —
+ * never silently downgraded to an unsorted list — for everyone else.
+ */
+class LastSeenSortTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-user-directory');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                [
+                    'id'                 => 3,
+                    'username'           => 'hidden',
+                    'password'           => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email'              => 'hidden@machine.local',
+                    'is_email_confirmed' => 1,
+                    'last_seen_at'       => '2026-01-01 00:00:00',
+                    // Opted out of disclosing online status.
+                    'preferences'        => json_encode(['discloseOnline' => false]),
+                ],
+                [
+                    'id'                 => 4,
+                    'username'           => 'visible',
+                    'password'           => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email'              => 'visible@machine.local',
+                    'is_email_confirmed' => 1,
+                    'last_seen_at'       => '2026-06-01 00:00:00',
+                    'preferences'        => json_encode(['discloseOnline' => true]),
+                ],
+            ],
+            'group_permission' => [
+                ['permission' => 'fof.user-directory.view', 'group_id' => 3],
+                ['permission' => 'searchUsers', 'group_id' => 3],
+            ],
+        ]);
+    }
+
+    protected function grantLastSeenToMembers(): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'user.viewLastSeenAt', 'group_id' => 3],
+            ],
+        ]);
+    }
+
+    /**
+     * The sort must be supplied via withQueryParams(): the test ServerRequest
+     * never parses a query string out of the path, so a `?sort=` in the URL is
+     * silently ignored and the assertion would pass against an unsorted list.
+     */
+    protected function sortRequest(string $sort, ?int $actor)
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
+        return $this->send(
+            $this->request('GET', '/api/users', $options)->withQueryParams(['sort' => $sort])
+        );
+    }
+
+    protected function usernamesFrom($response): array
+    {
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return array_column(array_column($data['data'], 'attributes'), 'username');
+    }
+
+    #[Test]
+    public function admin_can_sort_by_last_seen_descending()
+    {
+        $response = $this->sortRequest('-lastSeenAt', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_sort_by_last_seen_ascending()
+    {
+        $response = $this->sortRequest('lastSeenAt', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function descending_sort_orders_most_recently_seen_first()
+    {
+        $usernames = $this->usernamesFrom($this->sortRequest('-lastSeenAt', 1));
+
+        // 'visible' (June) was seen more recently than 'hidden' (January).
+        $this->assertLessThan(
+            array_search('hidden', $usernames),
+            array_search('visible', $usernames),
+            'Descending last-seen sort should place the more recently seen user first'
+        );
+    }
+
+    #[Test]
+    public function ascending_sort_orders_longest_away_first()
+    {
+        $usernames = $this->usernamesFrom($this->sortRequest('lastSeenAt', 1));
+
+        $this->assertLessThan(
+            array_search('visible', $usernames),
+            array_search('hidden', $usernames),
+            'Ascending last-seen sort should place the longest-absent user first'
+        );
+    }
+
+    /**
+     * The core regression from issue #66. A user without the permission asking
+     * for this sort must be rejected. If this ever returns 200 it means the
+     * sort silently degraded, which is how the beta 15 privacy leak worked.
+     */
+    #[Test]
+    public function normal_user_cannot_sort_by_last_seen_descending()
+    {
+        $response = $this->sortRequest('-lastSeenAt', 2);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normal_user_cannot_sort_by_last_seen_ascending()
+    {
+        $response = $this->sortRequest('lastSeenAt', 2);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function guest_cannot_sort_by_last_seen()
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'fof.user-directory.view', 'group_id' => 2],
+                ['permission' => 'searchUsers', 'group_id' => 2],
+            ],
+        ]);
+
+        $response = $this->sortRequest('-lastSeenAt', null);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normal_user_can_sort_by_last_seen_once_permission_is_granted()
+    {
+        $this->grantLastSeenToMembers();
+
+        $response = $this->sortRequest('-lastSeenAt', 2);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Sorting stays available to permitted actors, but the timestamp of a user
+     * who opted out of disclosing their online status must still be withheld.
+     * Core gates the *field* on `discloseOnline || can(viewLastSeenAt, $user)`
+     * separately from the sort, and this extension must not widen that.
+     */
+    #[Test]
+    public function last_seen_attribute_stays_hidden_from_users_without_permission()
+    {
+        $response = $this->send($this->request('GET', '/api/users', ['authenticatedAs' => 2]));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $byName = [];
+        foreach ($data['data'] as $user) {
+            $byName[$user['attributes']['username']] = $user['attributes'];
+        }
+
+        $this->assertArrayNotHasKey(
+            'lastSeenAt',
+            $byName['hidden'],
+            'A user who opted out of discloseOnline must not expose lastSeenAt'
+        );
+        $this->assertArrayHasKey(
+            'lastSeenAt',
+            $byName['visible'],
+            'A user who opted in to discloseOnline should still expose lastSeenAt'
+        );
+    }
+}

--- a/tests/integration/content/UserDirectorySortTest.php
+++ b/tests/integration/content/UserDirectorySortTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of fof/user-directory.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\UserDirectory\tests\integration\content;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The server-rendered /users page maps sort keys to API sort params itself.
+ * If it forwards `seen_recent` for an actor without `user.viewLastSeenAt`,
+ * the API throws and the whole page 500s — issue #66 all over again, but on
+ * first paint rather than on interaction. The page must degrade instead.
+ */
+class UserDirectorySortTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-user-directory');
+
+        $this->prepareDatabase([
+            User::class => [
+                // Given an explicit last_seen_at so ordering does not depend on
+                // how the database sorts NULLs.
+                $this->normalUser() + ['last_seen_at' => '2026-03-01 00:00:00'],
+                [
+                    'id'                 => 3,
+                    'username'           => 'hidden',
+                    'password'           => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email'              => 'hidden@machine.local',
+                    'is_email_confirmed' => 1,
+                    'last_seen_at'       => '2026-01-01 00:00:00',
+                    'preferences'        => json_encode(['discloseOnline' => false]),
+                ],
+                // Seeded last but seen most recently, so a working descending
+                // sort has to move it to the front of the id ordering.
+                [
+                    'id'                 => 4,
+                    'username'           => 'freshest',
+                    'password'           => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim',
+                    'email'              => 'freshest@machine.local',
+                    'is_email_confirmed' => 1,
+                    'last_seen_at'       => '2099-01-01 00:00:00',
+                    'preferences'        => json_encode(['discloseOnline' => true]),
+                ],
+            ],
+            'group_permission' => [
+                ['permission' => 'fof.user-directory.view', 'group_id' => 3],
+                ['permission' => 'searchUsers', 'group_id' => 3],
+            ],
+        ]);
+    }
+
+    protected function directoryRequest(string $sort, ?int $actor)
+    {
+        $options = $actor !== null ? ['authenticatedAs' => $actor] : [];
+
+        return $this->send(
+            $this->request('GET', '/users', $options)->withQueryParams(['sort' => $sort])
+        );
+    }
+
+    /**
+     * Reads the usernames out of the server-rendered list, in render order.
+     */
+    protected function renderedUsernames($response): array
+    {
+        preg_match_all('/<li>\s*(\S+)\s*<\/li>/', $response->getBody()->getContents(), $matches);
+
+        return $matches[1];
+    }
+
+    #[Test]
+    public function permitted_user_can_load_directory_sorted_by_recently_online()
+    {
+        $response = $this->directoryRequest('seen_recent', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $usernames = $this->renderedUsernames($response);
+
+        $this->assertNotEmpty($usernames, 'The directory should render users');
+        $this->assertEquals('freshest', $usernames[0], 'Descending last-seen sort should place the most recently seen user first');
+        $this->assertGreaterThan(
+            array_search('normal', $usernames),
+            array_search('hidden', $usernames),
+            'Descending last-seen sort should place the January user after the March one'
+        );
+    }
+
+    #[Test]
+    public function permitted_user_can_load_directory_sorted_by_longest_away()
+    {
+        $response = $this->directoryRequest('seen_oldest', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $usernames = $this->renderedUsernames($response);
+
+        $this->assertNotEmpty($usernames, 'The directory should render users');
+        $this->assertLessThan(
+            array_search('normal', $usernames),
+            array_search('hidden', $usernames),
+            'Ascending last-seen sort should place the January user before the March one'
+        );
+        $this->assertEquals('freshest', end($usernames), 'Ascending last-seen sort should place the most recently seen user last');
+    }
+
+    /**
+     * A crafted or bookmarked URL must not break the page for someone who
+     * lacks the permission. It should fall back to the default ordering.
+     */
+    #[Test]
+    public function unpermitted_user_falls_back_instead_of_erroring()
+    {
+        $response = $this->directoryRequest('seen_recent', 2);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Falling back must mean the sort is *dropped*, not applied anyway. If the
+     * unpermitted actor still sees last-seen ordering, the permission has been
+     * bypassed rather than respected.
+     */
+    #[Test]
+    public function unpermitted_user_does_not_receive_last_seen_ordering()
+    {
+        $permitted = $this->renderedUsernames($this->directoryRequest('seen_recent', 1));
+        $unpermitted = $this->renderedUsernames($this->directoryRequest('seen_recent', 2));
+
+        $this->assertNotEmpty($unpermitted, 'The directory should still render for an unpermitted actor');
+        $this->assertEquals('freshest', $permitted[0], 'Sanity check: the permitted actor does get last-seen ordering');
+        $this->assertNotSame(
+            $permitted,
+            $unpermitted,
+            'An unpermitted actor must not receive the last-seen ordering'
+        );
+    }
+
+    #[Test]
+    public function unpermitted_guest_falls_back_instead_of_erroring()
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['permission' => 'fof.user-directory.view', 'group_id' => 2],
+                ['permission' => 'searchUsers', 'group_id' => 2],
+            ],
+        ]);
+
+        $response = $this->directoryRequest('seen_recent', null);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function unrecognised_sort_still_loads()
+    {
+        $response = $this->directoryRequest('not_a_real_sort', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function directory_loads_without_a_sort()
+    {
+        $response = $this->send($this->request('GET', '/users', ['authenticatedAs' => 1]));
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #66.

Re-adds the `seen_recent` / `seen_oldest` sort options, this time gated behind core's `user.viewLastSeenAt` permission.

## Background

These sorts existed until `9b37481` (April 2021), which removed them to fix #66. The history there is worth restating, because it shapes the design:

- Flarum **beta 15** exposed the `lastSeenAt` sort to everyone, which let any user infer the online time of users who had opted out of disclosing it — a real privacy leak.
- **Beta 16** fixed it by restricting the sort to holders of `user.viewLastSeenAt`.
- This extension kept offering the option to everyone, so unpermitted users got an API error and lost the entire directory. The fix at the time was to drop the option rather than gate it.

Core still does all the sorting work — `UserResource::sorts()` registers `lastSeenAt` behind exactly that permission. So this PR adds no sorting logic; it only exposes the option to the actors who can actually use it.

## Changes

- **`userDirectoryCanSortByLastSeen`** forum attribute, mirroring the permission core puts on its own sort.
- **`SortMap::permissionedSortMap()`** — a separate map for gated sorts. `sortMap()` is unchanged, so third-party extenders that hook it (per the #123/#124 extensibility work) are unaffected. Extension authors can register their own gated sorts the same way.
- **`UserDirectoryListState`** filters options by permission, covering both the forum select and a crafted or bookmarked `?sort=` URL in one place.
- **Server-rendered directory** resolves the sort per-actor, so an unpermitted visitor falls back to default ordering instead of a 500 on first paint.
- **Admin default-sort dropdown excludes these options.** A forum-wide default that most users lack permission to perform is precisely what caused #66.
- Removed the `most_posts` / `least_posts` translations — they have been commented out of the sort maps since the beta 8 era and were never reachable.

## Privacy note

Core gates the *field* on `discloseOnline || can(viewLastSeenAt, $user)` but the *sort* on the flat permission alone. A permitted actor can therefore order by last-seen across users who opted out, without seeing their timestamps. That is core's own accepted tradeoff for a permission named "Always view user last seen time" — this PR neither widens nor narrows it, and there is a test pinning the field-level behaviour so it cannot drift.

## Tests

16 new integration tests across three files, covering both halves of the contract:

- The sort works for permitted actors and produces genuinely different ordering (not just a 200).
- It is **rejected, never silently ignored**, for unpermitted users and guests — silent degradation is how the beta 15 leak worked.
- The server-rendered page falls back rather than erroring, and the fallback really drops the sort rather than applying it anyway.
- A user who opted out of `discloseOnline` keeps their timestamp hidden regardless of the sort permission.

Two things worth flagging for reviewers:

1. Sorts must be passed with `withQueryParams()` in integration tests. The test `ServerRequest` never parses a query string out of the path, so `/api/users?sort=-lastSeenAt` is silently ignored and the assertions pass against an unsorted list. There is a comment on the helper about this.
2. I mutation-tested the gate — removing the `hasPermission` check makes three tests fail with the exact #66 symptom (400 for unpermitted users), so the guard is real rather than decorative.

`composer test:integration` → 34 tests, 84 assertions, all passing. PHPStan level 6 clean, typings and Prettier clean.