### PR TITLE
[2.x] perf: stop the directory refetching data it already has

### DIFF
--- a/js/src/forum/components/SearchField.tsx
+++ b/js/src/forum/components/SearchField.tsx
@@ -3,6 +3,7 @@ import Component, { type ComponentAttrs } from 'flarum/common/Component';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import withAttr from 'flarum/common/utils/withAttr';
 import KeyboardNavigatable from 'flarum/common/utils/KeyboardNavigatable';
+import setRouteWithForcedRefresh from 'flarum/common/utils/setRouteWithForcedRefresh';
 import ItemList from 'flarum/common/utils/ItemList';
 import type Mithril from 'mithril';
 import type Model from 'flarum/common/Model';
@@ -216,6 +217,8 @@ export default class SearchField<CustomAttrs extends ISearchFieldAttrs = ISearch
 
     this.qBuilder(params);
 
-    m.route.set(app.route('fof_user_directory', params));
+    // Forced: Mithril does not re-init a component when the route changes to
+    // the same one, so filtering from the directory would not reload the list.
+    setRouteWithForcedRefresh(app.route('fof_user_directory', params));
   }
 }

--- a/js/src/forum/components/UserDirectoryPage.tsx
+++ b/js/src/forum/components/UserDirectoryPage.tsx
@@ -9,6 +9,7 @@ import Button from 'flarum/common/components/Button';
 import Dropdown from 'flarum/common/components/Dropdown';
 import Separator from 'flarum/common/components/Separator';
 import extractText from 'flarum/common/utils/extractText';
+import setRouteWithForcedRefresh from 'flarum/common/utils/setRouteWithForcedRefresh';
 import Group from 'flarum/common/models/Group';
 import type Mithril from 'mithril';
 import UserDirectoryList from './UserDirectoryList';
@@ -42,11 +43,19 @@ export default class UserDirectoryPage<CustomAttrs extends IUserDirectoryPageAtt
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
 
-    this.state = new UserDirectoryListState({}, 1);
-
-    // Prefer the server-rendered payload so the first paint matches what the
-    // page was rendered with, falling back to the URL on client-side nav.
-    const preloaded = app.preloadedApiDocument<any>()?.payload?.fofUserDirectory;
+    // On the initial page load, prefer the server-rendered params so the first
+    // paint matches what the page was rendered with.
+    //
+    // Read straight from `app.data`: calling preloadedApiDocument() here would
+    // consume the preloaded document — it nulls itself after the first call —
+    // leaving the list state to refetch over the network on every page load.
+    //
+    // Unlike that document, this payload is never cleared, so it must only be
+    // trusted while the URL still matches the one the server rendered. After
+    // any navigation the URL is the source of truth, otherwise sorting and
+    // filtering would keep being overridden by the original request's params.
+    const preloaded =
+      window.location.href === app.initialRoute ? (app.data.fofUserDirectory as { q?: string; sort?: string } | undefined) : undefined;
 
     const q: string = (preloaded ? preloaded.q : m.route.param('q')) || '';
 
@@ -57,6 +66,8 @@ export default class UserDirectoryPage<CustomAttrs extends IUserDirectoryPageAtt
         this.enabledSpecialGroupFilters['flarum-suspend'] = 'is:suspended';
       }
     }
+
+    this.state = new UserDirectoryListState({}, 1);
 
     this.state.refreshParams(
       {
@@ -249,9 +260,10 @@ export default class UserDirectoryPage<CustomAttrs extends IUserDirectoryPageAtt
     // Remove qBuilder to avoid confusion.
     delete params.qBuilder;
 
-    this.state.refreshParams(params, 1);
-
-    m.route.set(app.route('fof_user_directory', params));
+    // Only set the route: changing it remounts the page, whose oninit seeds the
+    // state from the new params. Refreshing the state here as well would load
+    // the same page twice. Forced so Mithril re-inits on a same-route change.
+    setRouteWithForcedRefresh(app.route('fof_user_directory', params));
   }
 
   /**


### PR DESCRIPTION
The directory page made a redundant API request on **every page load**, and **two** on every sort change. Measured against core's index on a dev forum, that put roughly 1.5s between DOM ready and the first visible card, where the index rendered immediately. That gap is what made the page feel slow.

Worth saying up front: this is not query performance. I profiled the backend across every sort and filter first, and it was flat at ~350ms with 10–11 queries — within noise of core's own index page. The problem was entirely client-side.

## The preloaded document was consumed too early

`oninit` called `app.preloadedApiDocument()` only to read the `fofUserDirectory` payload key. That method is **single use** — it sets `app.data.apiDocument = null` on the first call. By the time `UserDirectoryListState::loadPage()` looked for the preloaded page, it was gone, so the list fetched over the network.

The page was consuming the preloaded document just to read a *different* payload key it never needed the document for. It now reads `app.data.fofUserDirectory` directly, leaving the document for `loadPage` to use as intended.

## Two requests when changing sort

`changeParams()` called `refreshParams()` **and** `m.route.set()`. The route change remounts the page, whose `oninit` refreshes the state again — so the same page loaded twice.

Core's `GlobalSearchState::changeSort()` only sets the route and lets the remount do the loading. This now matches, using core's `setRouteWithForcedRefresh` helper, which exists precisely because Mithril will not re-init a component when the route changes to the same one.

`SearchField::applyFiltering()` was already route-only, but used a plain `m.route.set` that would not re-init on the same route. It uses the same helper now.

## A latent bug this exposed

Removing the redundant refresh **broke sorting** — the URL updated but the list did not re-sort, and the select snapped back to "default".

`app.data.fofUserDirectory` is never cleared, unlike `apiDocument`. So every remount re-read the *original* server-rendered sort (`""`) and overrode the new URL param. The redundant `refreshParams()` had been masking this by loading the right params first.

The payload is now only trusted while `window.location.href === app.initialRoute` — the same guard core applies inside `preloadedApiDocument()`. After any navigation the URL is the source of truth.

This one is worth a moment's review: it is the subtle half of the change, and it only surfaced because the redundant request was hiding it.

## Measured

Driven through a real browser against a dev forum, 20 users per page:

| Action | Before | After |
|---|---|---|
| Direct page load | 1 request | **0** |
| Sort change | 2 requests | **1** |
| Deep-linked sort | 1 request | **0** |
| Deep-linked group filter | 1 request | **0** |
| DOM ready → first card | ~1700ms | **~24ms** |

Time-to-content is now at parity with core's index page on the same forum.

## Verification

Checked in a browser across: direct load, five different sorts (correct ordering and select value each time), deep-linked sort, deep-linked group filter, and browser reload. No console errors from the extension.

The loading spinner still behaves correctly — absent on direct load, where the data is already present, and shown on sort changes and client-side navigation, where a real request happens. Hero and toolbar stay in place throughout.

PHP suite unaffected: 123 tests passing, PHPStan level 6 clean, typings and Prettier clean.

## Note

There is no frontend test coverage yet, so this was verified by driving a real browser rather than by automated test. Worth a manual click-through before release, particularly the sort dropdown and group filters.