### PR TITLE
[2.x] perf: code split the user directory page

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -21,6 +21,7 @@ return [
 
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
+        ->jsDirectory(__DIR__.'/js/dist/forum')
         ->css(__DIR__.'/resources/less/forum.less')
         ->route('/users', 'fof_user_directory', Content\UserDirectory::class),
 

--- a/js/src/forum/components/UserDirectoryPage.tsx
+++ b/js/src/forum/components/UserDirectoryPage.tsx
@@ -194,6 +194,9 @@ export default class UserDirectoryPage<CustomAttrs extends IUserDirectoryPageAtt
       'refresh',
       <Button
         title={app.translator.trans('fof-user-directory.forum.page.refresh_tooltip')}
+        // Icon-only, so it needs an accessible name of its own: a title
+        // attribute alone leaves screen readers announcing just "Button".
+        aria-label={app.translator.trans('fof-user-directory.forum.page.refresh_tooltip')}
         icon="fas fa-sync"
         className="Button Button--icon"
         onclick={() => {

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -1,13 +1,13 @@
 import Extend from 'flarum/common/extenders';
 import Text from './models/Text';
-import UserDirectoryPage from './components/UserDirectoryPage';
 
 export default [
   new Extend.Store() //
     .add('fof-user-directory-text', Text),
 
   new Extend.Routes() //
-    // We don't code split this yet because it's fiddly with commonjs to import dynamically
-    // on the forum side, but normally on the admin side.
-    .add('fof_user_directory', '/users', UserDirectoryPage),
+    // Loaded on demand: the directory page and everything it pulls in (the
+    // cards, the search field, the filters) is only needed once someone
+    // actually visits /users.
+    .add('fof_user_directory', '/users', () => import('./components/UserDirectoryPage')),
 ];


### PR DESCRIPTION
## ⚠️ Merge order

This moves 13 modules out of the boot-time registry, which **breaks extensions that extend them by prototype at boot**. Two are affected, both fixed:

- FriendsOfFlarum/mailing#3 — hard crash without it
- FriendsOfFlarum/best-answer#134 — silent feature loss without it

**Both need releasing before this merges.** Anyone updating user-directory first gets a broken forum in between.

## What this does

The directory page, its cards, search field, filters and state all sat in the main forum bundle — loaded on every page of the forum for a route most visitors never open. Declaring the route with a dynamic import moves them into a chunk fetched on demand, and `jsDirectory` lets the backend serve it.

**`forum.js`: 19,368 → 9,048 bytes, a 53% reduction.** The 15KB chunk loads only on `/users`.

The comment claiming this was "fiddly with commonjs" is long out of date — `flarum-webpack-config` 3.x ships `RegisterAsyncChunksPlugin` and handles this directly.

## Why dependent extensions break

These 13 modules move out of the main registry and into the chunk:

```
UserDirectoryPage      UserDirectoryList      UserDirectoryListItem
UserDirectoryUserCard  UserDirectoryHero      SmallUserCard
SearchField            CheckableButton        UserDirectoryListState
SortMap                AbstractType           GroupFilter
TextFilter
```

Anything doing `extend(SomeModule.prototype, ...)` at boot now reads `.prototype` from `undefined`. For `fof/mailing` that threw during `initialize` and killed its entire initializer — the extension stopped working, not just the button. `fof/best-answer` had a null guard so it failed quietly, its sort options simply vanishing from the dropdown.

The fix in both cases is the documented one-liner — pass the import path to `extend` instead of the prototype, so the callback defers until the chunk loads. Worth flagging in the release notes for third parties doing the same.

## Also included

An `aria-label` on the refresh button. It is icon-only, and core warns that a `title` attribute alone leaves screen readers announcing just "Button":

```
[Flarum Accessibility Warning] Button has no content and no accessible label.
<button class="Button Button--icon hasIcon" type="button" title="Refresh">
```

Core pairs `title` and `aria-label` on its own icon buttons; this matches. It was the only such button in the extension.

## Verification

Driven through a real browser against a dev forum with both dependent extensions installed and enabled:

- `/users`, `?sort=`, `?q=group:N` deep links, browser reload — all render correctly
- Sort changes and client-side navigation work, chunk loads from `/assets/js/fof-user-directory/forum/components/UserDirectoryPage.js`
- `fof/mailing` "Send Email" button renders on the lazy page
- `fof/best-answer` sort options present
- No console errors, no accessibility warnings

PHP unaffected: 123 tests passing, PHPStan level 6 clean. Typings and Prettier clean.

## Note

There is still no frontend test coverage, so this was verified by driving a browser rather than by automated test. The dependent-extension breakage in particular was only caught that way — worth a manual pass before release.