### PR TITLE
[2.x] fix: stop directory filters leaking onto links away from the page

### DIFF
--- a/js/src/forum/extenders/extendGlobalSearchState.ts
+++ b/js/src/forum/extenders/extendGlobalSearchState.ts
@@ -1,0 +1,32 @@
+import app from 'flarum/forum/app';
+import { override } from 'flarum/common/extend';
+import GlobalSearchState from 'flarum/forum/states/GlobalSearchState';
+
+/**
+ * Stops the directory's `sort` and `q` leaking onto links that point away from
+ * it.
+ *
+ * Core keeps those two params "sticky" so a filter survives moving between
+ * discussion listings, and it does that by reading them straight off the
+ * current route. On the directory they mean something different — `sort` holds
+ * a directory sort key like `username_za`, and `q` holds group gambits — so
+ * every link built from them, including "All Discussions" and each tag, came
+ * out carrying a sort the discussion list cannot use.
+ *
+ * The directory's params are only meaningful on the directory, so nothing is
+ * sticky while it is the current page.
+ *
+ * The page is matched by path rather than by class: it is lazy loaded, so the
+ * module may not exist yet, and `matches()` resolves the path against the
+ * registry itself (returning false when it is not loaded — which is correct
+ * here, since an unloaded page cannot be the current one).
+ */
+export default function extendGlobalSearchState() {
+  override(GlobalSearchState.prototype, 'stickyParams', function (original) {
+    if (app.current?.matches('ext:fof/user-directory/forum/components/UserDirectoryPage')) {
+      return {};
+    }
+
+    return original();
+  });
+}

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -2,6 +2,7 @@ import app from 'flarum/forum/app';
 import extendCommentPost from './extenders/extendCommentPost';
 import extendUsersSearchSource from './extenders/extendUsersSearchSource';
 import extendIndexPage from './extenders/extendIndexPage';
+import extendGlobalSearchState from './extenders/extendGlobalSearchState';
 
 export { default as extend } from './extend';
 
@@ -9,4 +10,5 @@ app.initializers.add('fof-user-directory', function () {
   extendCommentPost();
   extendUsersSearchSource();
   extendIndexPage();
+  extendGlobalSearchState();
 });


### PR DESCRIPTION
Sorting or filtering the directory left those params stamped onto every link pointing away from it.

## Reproducing

1. Go to `/users`
2. Sort by "Username (z-a)" — URL becomes `/users?sort=username_za`
3. Click "All Discussions"

You land on `/?sort=username_za`, and the discussion list picks up `sort: "username_za"` — a *directory* sort key it has no idea what to do with. Every tag link in the sidebar carried it too:

```
/?sort=username_za
/t/general?sort=username_za
...
```

The same applies to `q`, which on the directory holds group gambits.

## Cause

Core keeps `sort` and `q` "sticky" so a filter survives moving between discussion listings, and `GlobalSearchState::stickyParams()` does that by reading them **straight off the current route**:

```ts
stickyParams(): SearchParams {
  return {
    sort: m.route.param('sort'),
    q: m.route.param('q'),
    filter: Object.assign({}, m.route.param('filter')),
  };
}
```

`IndexSidebar::navItems()` builds its links from that, so on the directory it happily picked up params that only mean something there.

Notably core *does* have a page-scoping mechanism — `providesInitialSearch`, which the directory correctly does not set — but it gates only the search *value*, not `stickyParams`. So there was no existing hook to opt out of.

## Fix

Override `stickyParams` to return nothing while the directory is the current page. Its params are meaningful only on the directory, so nothing should stick when leaving it. Fixing it at the source covers every consumer at once rather than patching individual links.

The page is matched **by import path** rather than by class:

```ts
app.current?.matches('ext:fof/user-directory/forum/components/UserDirectoryPage')
```

It is lazy loaded since #130, so the module may not be in the registry when this runs. `matches()` resolves the path itself and returns `false` when unloaded — the right answer here, since an unloaded page cannot be the current one. A static import would have reintroduced exactly the breakage #130 caused in fof/mailing.

## Verification

Driven through a browser against a dev forum.

Before — sidebar while sorted:
```
/?sort=username_za, /t/general?sort=username_za, ...
stickyParams: {"sort":"username_za","filter":{}}
```

After:
```
/, /t/general, ...
stickyParams: {}
```

Following "All Discussions" now lands on `/` with `discussions params: {"filter":{},"onFollowing":false}` — no leaked sort.

**Core's stickiness is untouched.** Starting from `/?sort=newest`, `stickyParams` still returns `{"sort":"newest","filter":{}}` and the tag link is still `/t/general?sort=newest`. Only the directory is excluded.

Also confirmed unaffected: the directory's own sorting, filtering, deep links and reload; the lazy chunk; fof/mailing's button; fof/best-answer's sort options; no console errors or accessibility warnings.

PHP suite unchanged — 123 passing, PHPStan level 6 clean, typings and Prettier clean.